### PR TITLE
Add a dependency for the api services on the reddit services.

### DIFF
--- a/roles/coda_apis/templates/etc/systemd/system/coda-container-api.service.j2
+++ b/roles/coda_apis/templates/etc/systemd/system/coda-container-api.service.j2
@@ -4,7 +4,7 @@
 
 [Unit]
 Description={{ container_name }}
-After=network.target
+After=network.target redis
 
 [Service]
 Type=simple


### PR DESCRIPTION
Add a dependency for the api services on the reddit services. This caused errors when rebooting the machine on the coda-learning-api service because redis was not started before.