### PR TITLE
Fmarois dev wip

### DIFF
--- a/group_vars/105
+++ b/group_vars/105
@@ -1,6 +1,13 @@
 ---
 
 coda_site_id: 105
+#_data_enabled: no
+
+################################################################################
+#### CODA-SITE-API
+################################################################################
+# Keycloak domain
+coda_site_api_keycloak_realm: coda19-dv
 
 # Image and tag to use
 coda_site_api_image_name: coda19/coda19-site-api

--- a/group_vars/all
+++ b/group_vars/all
@@ -71,3 +71,10 @@ coda_aidbox_firewalld_zones:
 coda_redis_firewalld_zones:
   - zone: local-green
     state: enabled
+
+################################################################################
+###### CODA_ORTHANC
+################################################################################
+
+coda_orthanc_group: orthanc
+coda_orthanc_user: orthanc

--- a/roles/coda_apis/defaults/main.yml
+++ b/roles/coda_apis/defaults/main.yml
@@ -23,6 +23,9 @@ coda_site_api_keycloak_client_id: coda19-site
 coda_site_api_stats_api_endpoint: http://localhost:5427
 coda_site_api_learning_api_endpoint: http://localhost:5445
 
+coda_site_api_keycloak_url: https://auth.hub.coda19.com/auth
+coda_site_api_keycloak_realm: coda19-pr
+
 # Image and tag to use
 coda_site_api_image_name: coda19/coda19-site-api
 coda_site_api_image_tag: latest

--- a/roles/coda_apis/templates/etc/default/coda-learning-api.j2
+++ b/roles/coda_apis/templates/etc/default/coda-learning-api.j2
@@ -7,3 +7,20 @@ CODA19_LEARNING_API_REDIS_PORT=6379
 CODA19_LEARNING_API_AIDBOX_URL={{ coda_stats_api_aidbox_url }}
 CODA19_LEARNING_API_CLIENT_ID={{ coda_learning_api_aidbox_client_id }}
 CODA19_LEARNING_API_CLIENT_SECRET={{ coda_aidbox_conf_client_secret | default('') }}
+
+
+CODA_LEARNING_API_PORT={{ coda_learning_api_port }}
+#CODA_LEARNING_API_IS_LOCAL_DEV=true
+
+CODA_FHIR_STORE_URL={{ coda_stats_api_aidbox_url }}
+CODA_LEARNING_API_FHIR_STORE_CLIENT_ID={{ coda_learning_api_aidbox_client_id }}
+CODA_LEARNING_API_FHIR_STORE_CLIENT_SECRET={{ coda_aidbox_conf_client_secret | default('') }}
+
+CODA_SITE_CACHE_DB_HOST=localhost
+CODA_SITE_CACHE_DB_PORT=6379
+#CODA_SITE_CACHE_DB_USERNAME=''
+#CODA_SITE_CACHE_DB_PASSWORD=''
+
+CODA_DICOM_STORE_URL=http://localhost:8042
+CODA_LEARNING_API_DICOM_STORE_CLIENT_ID= {{ coda_orthanc_user }}
+CODA_LEARNING_API_DICOM_STORE_CLIENT_SECRET={{ coda_orthanc_password }}

--- a/roles/coda_apis/templates/etc/default/coda-site-api.j2
+++ b/roles/coda_apis/templates/etc/default/coda-site-api.j2
@@ -13,3 +13,15 @@ CODA19_SITE_API_LEARNING_API_ENDPOINT={{ coda_site_api_learning_api_endpoint }}
 
 # TODO: manage proxy correctly
 #CODA19_SITE_API_PROXY={{ coda_site_api_websocket_proxy | default('') }}
+
+CODA_SITE_API_SERVER_PORT={{ coda_site_api_port }}
+CODA_HUB_API_URL={{ coda_green_hub_api_url }}
+#CODA_SITE_API_PROXY_URL={{ coda_site_api_websocket_proxy | default('') }}
+CODA_SITE_API_HOSPITAL_CODE={{ coda_site_id }}
+CODA_AUTH_SERVICE_URL={{ coda_site_api_keycloak_url }}
+CODA_SITE_API_AUTH_REALM={{ coda_site_api_keycloak_realm }}
+CODA_SITE_API_AUTH_CLIENT_ID={{ coda_site_api_keycloak_client_id }}
+CODA_SITE_API_AUTH_USERNAME={{ coda19_site_api_keycloak_app_username }}
+CODA_SITE_API_AUTH_PASSWORD={{ coda19_site_api_keycloak_app_password }}
+CODA_STATS_API_URL={{ coda_site_api_stats_api_endpoint }}
+CODA_LEARNING_API_URL={{ coda_site_api_learning_api_endpoint }}

--- a/roles/coda_apis/templates/etc/default/coda-stats-api.j2
+++ b/roles/coda_apis/templates/etc/default/coda-stats-api.j2
@@ -6,3 +6,8 @@ CODA19_STATS_API_FAKE_AIDBOX={{ coda_stats_api_fake_aidbox }}
 CODA19_STATS_API_AIDBOX_URL={{ coda_stats_api_aidbox_url }}
 CODA19_STATS_API_CLIENT_ID={{ coda_stats_api_aidbox_client_id }}
 CODA19_STATS_API_CLIENT_SECRET={{ coda_aidbox_conf_client_secret | default('') }}
+
+CODA_STATS_API_PORT={{ coda_stats_api_port }}
+CODA_FHIR_STORE_URL={{ coda_stats_api_aidbox_url }}
+CODA_STATS_API_FHIR_STORE_CLIENT_ID={{ coda_stats_api_aidbox_client_id }}
+CODA_STATS_API_FHIR_STORE_CLIENT_SECRET={{ coda_aidbox_conf_client_secret | default('') }}

--- a/roles/coda_apis/templates/usr/local/bin/cleanup-apis.sh.j2
+++ b/roles/coda_apis/templates/usr/local/bin/cleanup-apis.sh.j2
@@ -14,6 +14,7 @@ kill -15 $PID 2>/dev/null
 sleep 5
 kill -9 $PID  2>/dev/null
 podman rmi --force docker.io/coda/coda-learning-api:latest
+podman rmi --force docker.io/coda/coda-learning-api:dev
 podman system prune --all --force && podman rmi --all
 EOF
 echo "=== coda-learning-api cleanup finished ==="
@@ -29,6 +30,7 @@ kill -15 $PID 2>/dev/null
 sleep 5
 kill -9 $PID  2>/dev/null
 podman rmi --force docker.io/coda/coda-stats-api:latest
+podman rmi --force docker.io/coda/coda-stats-api:dev
 podman system prune --all --force && podman rmi --all
 EOF
 echo "=== coda-stats-api cleanup finished ==="
@@ -44,6 +46,7 @@ kill -15 $PID 2>/dev/null
 sleep 5
 kill -9 $PID  2>/dev/null
 podman rmi --force docker.io/coda/coda-site-api:latest
+podman rmi --force docker.io/coda/coda-site-api:dev
 podman system prune --all --force && podman rmi --all
 EOF
 echo "=== coda-site-api cleanup finished ==="

--- a/roles/coda_dicom_store/defaults/main.yml
+++ b/roles/coda_dicom_store/defaults/main.yml
@@ -6,9 +6,6 @@ coda_orthanc_firewalld_zones:
   - zone: public
     state: enabled
 
-coda_orthanc_group: orthanc
-coda_orthanc_user: orthanc
-
 coda_orthanc_image_repo: docker.io
 coda_orthanc_image_name: osimis/orthanc
 coda_orthanc_image_tag: 22.7.0

--- a/roles/coda_podman/tasks/configure.yml
+++ b/roles/coda_podman/tasks/configure.yml
@@ -21,3 +21,18 @@
     name: user.max_user_namespaces
     value: "{{ coda_podman_max_user_namespaces }}"
     state: present
+
+#This options is to use cgroupfs instead of systemd. 
+- name: "LINEINFILE | Edit containers.conf file cgroup_manager to cgroupfs"
+  lineinfile:
+    path: /usr/share/containers/containers.conf
+    regexp: '#cgroup_manager = "systemd"'
+    line: 'cgroup_manager = "cgroupfs"'
+
+#This option is to prevent error from containers when too many subuid are used
+- name: "LINEINFILE | Edit storage.conf file to ignore chown errors"
+  lineinfile:
+    path: /etc/containers/storage.conf
+    regexp: '#ignore_chown_errors = "false"'
+    line: 'ignore_chown_errors = "true"'
+


### PR DESCRIPTION
Modification to add new variables for the dev versions of the apis.
Moved the image store username and groupname to all group vars to be accessible by api roles.
Added necessary variables to coda apis templates.
Added the dev version of images to the cleanup api script.
Edit the container.conf file to set cgroup as default for process
management. (Caused warnings in RHEL9).
Edit the storage.conf to ignore chown_errors. The dev version of
learning api caused error because it was using too many subuid.